### PR TITLE
fixed library linking for Pleiades

### DIFF
--- a/optfiles/linux_amd64_ifort+mpi_ice_nas_all
+++ b/optfiles/linux_amd64_ifort+mpi_ice_nas_all
@@ -8,7 +8,7 @@
 # Be sure to load modules: 
 #       module load comp-intel 
 #       module load mpi-sgi/mpt 
-#       module load netcdf/4.1.2
+#       module load netcdf
 #
 # ------------------------------------------------------------------------------------
 
@@ -22,8 +22,8 @@ OMPFLAG='-openmp'
 CFLAGS='-fPIC'
 LDADD='-shared-intel'
 
-NETCDF_DIR=/nasa/netcdf/4.4.1.1_serial
-LIBS="-L${MPI_ROOT}/lib -lmpi -L${NETCDF_DIR}/lib -lnetcdf"
+NETCDF_DIR=$NETCDF
+LIBS="-L${MPI_ROOT}/lib -lmpi -L${NETCDF_DIR}/lib -lnetcdf -lnetcdff"
 INCLUDES="-I${MPI_ROOT}/include -I${NETCDF_DIR}/include"
 INCLUDEDIRS="${MPI_ROOT}/include ${NETCDF_DIR}/include"
 #- used for parallel (MPI) DIVA

--- a/optfiles/linux_amd64_ifort+mpi_ice_nas_haswell
+++ b/optfiles/linux_amd64_ifort+mpi_ice_nas_haswell
@@ -8,7 +8,7 @@
 # Be sure to load modules: 
 #       module load comp-intel 
 #       module load mpi-sgi/mpt 
-#       module load netcdf/4.1.2
+#       module load netcdf
 #
 # ------------------------------------------------------------------------------------
 
@@ -22,8 +22,9 @@ OMPFLAG='-openmp'
 CFLAGS='-fPIC'
 LDADD='-shared-intel'
 
-NETCDF_DIR=/nasa/netcdf/4.4.1.1_serial
-LIBS="-L${MPI_ROOT}/lib -lmpi -L${NETCDF_DIR}/lib -lnetcdf"
+# This is the environment variable set by module load netcdf
+NETCDF_DIR=$NETCDF
+LIBS="-L${MPI_ROOT}/lib -lmpi -L${NETCDF_DIR}/lib -lnetcdf -lnetcdff"
 INCLUDES="-I${MPI_ROOT}/include -I${NETCDF_DIR}/include"
 INCLUDEDIRS="${MPI_ROOT}/include ${NETCDF_DIR}/include"
 #- used for parallel (MPI) DIVA

--- a/optfiles/linux_amd64_ifort+mpi_ice_nas_ivy
+++ b/optfiles/linux_amd64_ifort+mpi_ice_nas_ivy
@@ -8,7 +8,7 @@
 # Be sure to load modules: 
 #       module load comp-intel 
 #       module load mpi-sgi/mpt 
-#       module load netcdf/4.1.2
+#       module load netcdf
 #
 # ------------------------------------------------------------------------------------
 
@@ -23,8 +23,8 @@ OMPFLAG='-openmp'
 CFLAGS='-fPIC'
 LDADD='-shared-intel'
 
-NETCDF_DIR=/nasa/netcdf/4.4.1.1_serial
-LIBS="-L${MPI_ROOT}/lib -lmpi -L${NETCDF_DIR}/lib -lnetcdf"
+NETCDF_DIR=$NETCDF
+LIBS="-L${MPI_ROOT}/lib -lmpi -L${NETCDF_DIR}/lib -lnetcdf -lnetcdff"
 INCLUDES="-I${MPI_ROOT}/include -I${NETCDF_DIR}/include"
 INCLUDEDIRS="${MPI_ROOT}/include ${NETCDF_DIR}/include"
 #- used for parallel (MPI) DIVA


### PR DESCRIPTION
This PR
- fixes the netcdf library linking on Pleiades
- changes the `NETCDF_DIR` variable to the environment variable `$NETCDF` which is set with `module load netcdf`