### PR TITLE
Streamline jupyter notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@
     Note that the same optfiles for stampede2 are now available in the [MITgcm repo](https://github.com/MITgcm/MITgcm)
     see here for [KNL](https://github.com/MITgcm/MITgcm/blob/master/tools/build_options/linux_amd64_ifort%2Bimpi_stampede2_knl)
     and [SKX](https://github.com/MITgcm/MITgcm/blob/master/tools/build_options/linux_amd64_ifort%2Bimpi_stampede2_skx) architectures
+
+  - useful-bash/ miscellanious helpful bash scripts

--- a/useful-bash/connect_to_sverdrup_notebook.sh
+++ b/useful-bash/connect_to_sverdrup_notebook.sh
@@ -4,7 +4,8 @@
 # The steps are:
 #   1. Connect to sverdrup and open up interactive session on a compute node
 #   2. Execute 'open_notebook_on_sverdrup.sh' on the compute node
-#   3. This returns an IP address, say XX.X.X.X
+#   3. This returns an IP address, saying
+#       "your internet connection is: XX.X.X.X"
 #   4. Use the alias below on your local machine (e.g. your laptop) to connect as:
 #       jupytersv XX.X.X.X 
 #   5. Open up a web browser and navigate to

--- a/useful-bash/connect_to_sverdrup_notebook.sh
+++ b/useful-bash/connect_to_sverdrup_notebook.sh
@@ -1,0 +1,25 @@
+#!/bin/bash 
+
+# Add this to your bashrc to connect to jupyter notebooks on Sverdrup easier.
+# The steps are:
+#   1. Connect to sverdrup and open up interactive session on a compute node
+#   2. Execute 'open_notebook_on_sverdrup.sh' on the compute node
+#   3. This returns an IP address, say XX.X.X.X
+#   4. Use the alias below on your local machine (e.g. your laptop) to connect as:
+#       jupytersv XX.X.X.X 
+#   5. Open up a web browser and navigate to
+#       https://localhost:PPPP
+#      where PPPP is the port_number set below
+
+### Connect to Jupyter notebook on Sverdrup ###
+# For compute node notebook, need to pass IP address
+# The alias below does this by:
+#   1. Create a temporary function which takes in passed arguments
+#   2. unset the temp function after running the desired ssh command
+#   3. execute
+export port_number='8890'
+export ssh_jump='-J login1.ices.utexas.edu'
+alias jupytersv='temporary_function(){
+    ssh -p 8704 -i ~/.ssh/sverdrup_rsa '$ssh_jump' -L localhost:'$port_number':"$@":'$port_number' sverdrup.ices.utexas.edu; 
+    unset -f temporary_function;}; 
+    temporary_function'

--- a/useful-bash/open_notebook_on_sverdrup.sh
+++ b/useful-bash/open_notebook_on_sverdrup.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# A script to get a notebook going on sverdrup compute node
+unset XDG_RUNTIME_DIR
+
+# get the internet connection
+export internet_connect=`ip address show eth0 | grep -Po '(?<=[inet]) (\d+\.\d+\.\d+\.\d+)' | sed 's: ::g'`
+
+echo 'internet connection is:' $internet_connect
+
+# open the notebook
+jupyter notebook --no-browser --port=8890 --ip=$internet_connect

--- a/useful-bash/open_notebook_on_sverdrup.sh
+++ b/useful-bash/open_notebook_on_sverdrup.sh
@@ -3,6 +3,8 @@
 # Run this on a compute node, then use the alias'd ssh function to 
 # connect to the notebook on your local machine (i.e. your laptop)
 
+# Please see 'connect_to_sverdrup_notebook.sh' for instructions on how to use this
+
 export port_number=8890
 
 # A script to get a notebook going on sverdrup compute node

--- a/useful-bash/open_notebook_on_sverdrup.sh
+++ b/useful-bash/open_notebook_on_sverdrup.sh
@@ -1,5 +1,10 @@
 #! /bin/bash
 
+# Run this on a compute node, then use the alias'd ssh function to 
+# connect to the notebook on your local machine (i.e. your laptop)
+
+export port_number=8890
+
 # A script to get a notebook going on sverdrup compute node
 unset XDG_RUNTIME_DIR
 
@@ -9,4 +14,4 @@ export internet_connect=`ip address show eth0 | grep -Po '(?<=[inet]) (\d+\.\d+\
 echo 'internet connection is:' $internet_connect
 
 # open the notebook
-jupyter notebook --no-browser --port=8890 --ip=$internet_connect
+jupyter notebook --no-browser --port=$port_number --ip=$internet_connect


### PR DESCRIPTION
Two scripts which make connecting to notebooks on sverdrup compute nodes a breeze. 
See comments in useful-bash/connect_to_sverdrup_notebook.sh for instructions