### PR TITLE
mcmodel large for ecco adjoint

### DIFF
--- a/optfiles/linux_amd64_ifort+mpi_ice_nas_all
+++ b/optfiles/linux_amd64_ifort+mpi_ice_nas_all
@@ -50,5 +50,5 @@ fi
 #FFLAGS="$FFLAGS -r8"
 
 #- For really big executable (> 2 GB), uncomment following 2 lines
-#FFLAGS="$FFLAGS -mcmodel=medium -shared-intel"
-#CFLAGS="$CFLAGS -mcmodel=medium -shared-intel"
+FFLAGS="$FFLAGS -mcmodel=large -shared-intel"
+CFLAGS="$CFLAGS -mcmodel=large -shared-intel"

--- a/optfiles/linux_amd64_ifort+mpi_ice_nas_haswell
+++ b/optfiles/linux_amd64_ifort+mpi_ice_nas_haswell
@@ -51,5 +51,5 @@ fi
 #FFLAGS="$FFLAGS -r8"
 
 #- For really big executable (> 2 GB), uncomment following 2 lines
-#FFLAGS="$FFLAGS -mcmodel=medium -shared-intel"
-#CFLAGS="$CFLAGS -mcmodel=medium -shared-intel"
+FFLAGS="$FFLAGS -mcmodel=large -shared-intel"
+CFLAGS="$CFLAGS -mcmodel=large -shared-intel"

--- a/optfiles/linux_amd64_ifort+mpi_ice_nas_ivy
+++ b/optfiles/linux_amd64_ifort+mpi_ice_nas_ivy
@@ -51,5 +51,5 @@ fi
 #FFLAGS="$FFLAGS -r8"
 
 #- For really big executable (> 2 GB), uncomment following 2 lines
-#FFLAGS="$FFLAGS -mcmodel=medium -shared-intel"
-#CFLAGS="$CFLAGS -mcmodel=medium -shared-intel"
+FFLAGS="$FFLAGS -mcmodel=large -shared-intel"
+CFLAGS="$CFLAGS -mcmodel=large -shared-intel"


### PR DESCRIPTION
make mcmodel=large the default, because we love the adjoint