### PR TITLE
Added chrome localhost permissions step to jupyter/README.md

### DIFF
--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -134,4 +134,4 @@
 
     6. Open up a web browser and navigate to https://localhost:PPPP.
     
-    7. If using Google Chrome, you may need to allow requests to localhost. Head to chrome://flags/#allow-insecure-localhost and enable the option "Allow invalid certficates for resources loaded from localhost."
+    7. If using Google Chrome, you may be told that connection to localhost is insecure. To continue, click anywhere on the Chrome window and type "thisisunsafe", and you will arrive at a jupyter notebook login screen. Enter your Sverdrup password to proceed.

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -134,4 +134,4 @@
 
     6. Open up a web browser and navigate to https://localhost:PPPP.
     
-    7. If using Google Chrome, you may need to allow requests to localhost. Head to chrome://flags/#allow-insecure-localhost and enable the option "Allow invalid certficates for resources loaded from localhost
+    7. If using Google Chrome, you may need to allow requests to localhost. Head to chrome://flags/#allow-insecure-localhost and enable the option "Allow invalid certficates for resources loaded from localhost."

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -133,3 +133,5 @@
        ```
 
     6. Open up a web browser and navigate to https://localhost:PPPP.
+    
+    7. If using Google Chrome, you may need to allow requests to localhost. Head to chrome://flags/#allow-insecure-localhost and enable the option "Allow invalid certficates for resources loaded from localhost


### PR DESCRIPTION
In order to connect to a jupyter notebook launched on Sverdrup, I needed to perform one additional step within Chrome from my laptop. @Shreyas911 directed me to an email thread in which this issue had been discussed by @timothyas  and @hpillar -- they may have come up with a different solution. 