### PR TITLE
Updated module purge/load for working optfile on LS6

### DIFF
--- a/optfiles/linux_amd64_ifort+mpi_lonestar6
+++ b/optfiles/linux_amd64_ifort+mpi_lonestar6
@@ -2,8 +2,15 @@
 #
 # For running on TACC's Lonestar 6, AMD Epyc Milan processors
 #
-# Make sure the following modules are loaded:
-#   intel/19.1.1 impi/19.0.9 netcdf/4.6.2 
+# An's fix 30June2022: now need to purge all other modules,
+# then load correct intel/mpi/netcdf or will fail to compile
+# with netcdf and flush. Do the following on the command line
+# or in bashrc:
+#
+# module purge
+# module load intel/19.1.1 impi/19.0.9 netcdf/4.6.2 
+#
+# This optfile then gives successful compilation of ECCOv4r4 & ASTE
 
 CC=icc
 FC=ifort


### PR DESCRIPTION
Now need to purge all modules except correct mpi/netcdf/intel to get successful compilation of ECCO/ASTE with this optfile on LS6. Thanks Ivana & An for fix :)